### PR TITLE
Improve docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ If you want a consistent emoji style, you can set it in your ``conf.py`` file:
 
    sphinxemoji_style = 'twemoji'
 
-You can find the list of all supported emoji codes `here
+You can find the list of all supported emoji codes `in the project's documentation page
 <https://sphinxemojicodes.readthedocs.io/#supported-codes>`_.
 
 

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ If you want a consistent emoji style, you can set it in your ``conf.py`` file:
 
    sphinxemoji_style = 'twemoji'
 
-You can find a list of all supported emoji codes in `the project's documentation page
-<https://sphinxemojicodes.readthedocs.io/>`_.
+You can find the list of all supported emoji codes `here
+<https://sphinxemojicodes.readthedocs.io/#supported-codes>`_.
 
 
 Notes

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,15 +8,6 @@ Sphinx Emoji Codes - |version|
 .. include:: ../../README.rst
    :start-line: 3
 
-Supported Codes
----------------
-
-Sphinx Emoji Codes supports many emoji codes. It currently combines the
-following sources:
-
-- `gemojione <https://github.com/bonusly/gemojione`_
-- `joypixels <https://github.com/joypixels>`_
-
 Supported Styles
 ----------------
 
@@ -30,6 +21,12 @@ Currently there is just one supported style, `Twemoji <https://twemoji.twitter.c
 Supported Codes
 ---------------
 
-Sphinx Emoji Codes supports the same set of emoji codes used in `GitLab <https://gitlab.com/>`_. Here is the full list of supported emoji codes, sorted alphabetically:
+Sphinx Emoji Codes supports many emoji codes. It currently combines the
+following sources:
+
+- `gemojione <https://github.com/bonusly/gemojione`_
+- `joypixels <https://github.com/joypixels>`_
+
+Here is the full list of supported emoji codes, sorted alphabetically:
 
 .. sphinxemojitable::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,12 +5,31 @@ Sphinx Emoji Codes - |version|
 .. toctree::
    :maxdepth: 2
 
+.. include:: ../../README.rst
+   :start-line: 3
+
+Supported Codes
+---------------
+
 Sphinx Emoji Codes supports many emoji codes. It currently combines the
 following sources:
 
 - `gemojione <https://github.com/bonusly/gemojione`_
 - `joypixels <https://github.com/joypixels>`_
 
-Here is the full list of supported emoji codes, sorted alphabetically:
+Supported Styles
+----------------
+
+Currently there is just one supported style, `Twemoji <https://twemoji.twitter.com/>`_. Feel free to `contribute <https://github.com/sphinx-contrib/emojicodes>`_ other styles if you want, just please pay attention to the licensing. The relevant code can be found in ``sphinxemoji/sphinxemoji.py``:
+
+.. literalinclude::  ../../sphinxemoji/sphinxemoji.py
+   :language: python
+   :lines: 58-62
+
+
+Supported Codes
+---------------
+
+Sphinx Emoji Codes supports the same set of emoji codes used in `GitLab <https://gitlab.com/>`_. Here is the full list of supported emoji codes, sorted alphabetically:
 
 .. sphinxemojitable::


### PR DESCRIPTION
While working on https://github.com/sphinx-contrib/emojicodes/issues/11 I spotted there's something wrong with the gay pride flag (it displayed to me as two characters - rainbow and the white flag), so I overwrote it with whatever the Apple's character map has produced for me. Now it displayes correctly on my computer.

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/283441/77232724-2bfc0780-6ba3-11ea-98ce-3b32babe54d9.png">
