### PR TITLE
specify minimum Sphinx requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
         ],
     },
     install_requires=[
-        'sphinx',
+        'sphinx>=1.7',
     ],
 )


### PR DESCRIPTION
Sphinx 1.7 was the first Sphinx release to introduce the
[sphinx.registry.create_source_parser](https://github.com/sphinx-doc/sphinx/blob/50fd2ff51056d7f000a9e3ebeb7c4b6e5a84e387/sphinx/registry.py#L279-L284)
function used here: https://github.com/sphinx-contrib/emojicodes/blob/44640719fd1dfd98ea7a75b166e8cd47a3b14a60/sphinxemoji/sphinxemoji.py#L20

Prior versions of Sphinx cannot use emojicodes.