### PR TITLE
Add CI configuration and tests, perform simple fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install sphinxemoji and all its requirements
-      run: python -m pip install -e .
+      run: python -m pip install -e .[ci]
     - name: Test
-      run: python -c 'from sphinxemoji import sphinxemoji'  # dummy test
+      run: |
+        doc8 README.rst
+        doc8 docs/source/
+        make -C docs html SPHINXOPTS="-W -E"
+        make -C docs linkcheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: main
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install sphinxemoji and all its requirements
+      run: python -m pip install -e .
+    - name: Test
+      run: python -c 'from sphinxemoji import sphinxemoji'  # dummy test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,10 @@ name: main
 on: push
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 
 class SphinxEmojiTable(Directive):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Sphinx Emoji Codes - |version|
 Sphinx Emoji Codes supports many emoji codes. It currently combines the
 following sources:
 
-- `gemojione <https://github.com/bonusly/gemojione`_
+- `gemojione <https://github.com/bonusly/gemojione>`_
 - `joypixels <https://github.com/joypixels>`_
 
 Here is the full list of supported emoji codes, sorted alphabetically:

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,9 @@ setup(
     install_requires=[
         'sphinx>=1.7',
     ],
+    extras_require={
+        'ci': [
+            'doc8',
+        ]
+    },
 )


### PR DESCRIPTION
Implements and closes https://github.com/sphinx-contrib/emojicodes/issues/13. Doesn't make the tests pass, because I was unable to debug the following problems:

```
/Users/honza/Projects/emojicodes/docs/source/index.rst:5: WARNING: Inline emphasis start-string without end-string.
/Users/honza/Projects/emojicodes/docs/source/index.rst:5: WARNING: Inline emphasis start-string without end-string.
/Users/honza/Projects/emojicodes/docs/source/index.rst:5: WARNING: Inline emphasis start-string without end-string.
```

If those are fixed, I believe the tests will pass. Under https://github.com/honzajavorek/emojicodes/pull/1 it should be visible how it works.

The Windows tests will probably fail as well even when the other will pass, because I'd say `make` won't be installed out of the box, but that can be later fixed simply by `choco install make` I think. Let's see. It'd focus on making it pass on Linux/macOS now. Also, perhaps it doesn't make sense to test the docs on multiple OS'es and it's okay to test it just on Linux. We'd test on multiple OS'es only if we have real tests for the code. But so far I'm keeping what I have as a demonstration of what's possible if we make it pass, and we can expand on that / restructure it later.