### PR TITLE
Replaced calls to deprecated Sphinx methods with the new versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
         ],
     },
     install_requires=[
-        'sphinx>=1.7',
+        'sphinx>=1.8',
     ],
 )

--- a/sphinxemoji/sphinxemoji.py
+++ b/sphinxemoji/sphinxemoji.py
@@ -57,8 +57,8 @@ def setup(app):
     app.connect('build-finished', copy_asset_files)
     style = app.config._raw_config.get('sphinxemoji_style')
     if style == 'twemoji':
-        app.add_javascript('https://twemoji.maxcdn.com/v/latest/twemoji.min.js')
-        app.add_javascript('twemoji.js')
-        app.add_stylesheet('twemoji.css')
+        app.add_js_file('https://twemoji.maxcdn.com/v/latest/twemoji.min.js')
+        app.add_js_file('twemoji.js')
+        app.add_css_file('twemoji.css')
     app.add_transform(EmojiSubstitutions)
     return {'version': __version__, 'parallel_read_safe': True}


### PR DESCRIPTION
This should fix https://github.com/sphinx-contrib/emojicodes/issues/19

I've built the documentation as a test, with `sphinxemoji_style = 'twemoji'` in `conf.py`. The "RemovedInSphinx40Warning" is no longer being shown and the emojis are still showing correctly, so I think it's all working.