### PR TITLE
Specify encoding for `open()`

### DIFF
--- a/sphinxemoji/sphinxemoji.py
+++ b/sphinxemoji/sphinxemoji.py
@@ -1,5 +1,6 @@
 import os
 import json
+from io import open
 from pkg_resources import resource_filename
 
 from docutils import nodes
@@ -23,7 +24,7 @@ class EmojiSubstitutions(SphinxTransform):
         config = self.document.settings.env.config
         settings, source = self.document.settings, self.document['source']
         codes = resource_filename(__name__, 'codes.json')
-        replacements = json.load(open(codes))
+        replacements = json.load(open(codes, encoding='utf-8'))
         to_handle = (set(replacements.keys()) -
                      set(self.document.substitution_defs))
 

--- a/sphinxemoji/utils.py
+++ b/sphinxemoji/utils.py
@@ -1,4 +1,5 @@
 import json
+from io import open
 from urllib.request import urlopen
 
 
@@ -27,14 +28,14 @@ def get_joypixels():
 
 
 def update_codes():
-    with open('sphinxemoji/codes.json') as current:
+    with open('sphinxemoji/codes.json', encoding='utf-8') as current:
         codes = json.load(current)
     for getter in [
         get_gemojione,
         get_joypixels,
     ]:
         codes.update(getter())
-    with open('sphinxemoji/codes.json', 'w') as output:
+    with open('sphinxemoji/codes.json', 'w', encoding='utf-8') as output:
         json.dump(codes, output, sort_keys=True, indent=4, ensure_ascii=False)
         output.write('\n')
 


### PR DESCRIPTION
This PR adds an `encoding` parameter to all calls to the builtin `open()` function in this project.

Using `open()` without an explicit encoding is a common mistake (see [PEP 597](https://www.python.org/dev/peps/pep-0597/)). The system default encoding is implicitly being used, making this library unusable on Windows (and possibly also on some Docker containers with locale not set) without patch.

Since the `codes.json` file is totally controlled by us (and known to be UTF-8 encoded), just specify UTF-8 encoding for `open()` explicitly. The `from io import open` statement is for Python 2 compatibility (if still desired), since the builtin `open()` function in Python 2 does not allow specifying an encoding.

This fixes #9, which has been there for a long time but no PRs have been created.