### PR TITLE
Ensure codes.json is closed after reading.

### DIFF
--- a/sphinxemoji/sphinxemoji.py
+++ b/sphinxemoji/sphinxemoji.py
@@ -23,7 +23,10 @@ class EmojiSubstitutions(SphinxTransform):
         config = self.document.settings.env.config
         settings, source = self.document.settings, self.document['source']
         codes = resource_filename(__name__, 'codes.json')
-        replacements = json.load(open(codes, encoding='utf-8'))
+
+        with open(codes, encoding='utf-8') as fp:
+            replacements = json.load(fp)
+
         to_handle = (set(replacements.keys()) -
                      set(self.document.substitution_defs))
 


### PR DESCRIPTION
The current approach leaves the file handle open, which is not recommended. 
Instead, the context manager will close the file after the JSON content has been read.