### PR TITLE
Update Twemoji source config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,14 @@ If you want a consistent emoji style, you can set it in your ``conf.py`` file:
 
    sphinxemoji_style = 'twemoji'
 
+By default twemoji is obtained from a CDN. If you want to specify your own
+source location (be it local or from another CDN), you can do so via the ``conf.py`` file:
+
+.. code:: python
+
+   sphinxemoji_source = 'https://unpkg.com/twemoji@latest/dist/twemoji.min.js'
+   # or: sphinxemoji_source = 'my-local-twemoji.min.js'
+
 You can find the list of all supported emoji codes `in the project's documentation page
 <https://sphinxemojicodes.readthedocs.io/#supported-codes>`_.
 

--- a/sphinxemoji/sphinxemoji.py
+++ b/sphinxemoji/sphinxemoji.py
@@ -13,7 +13,7 @@ from . import __version__
 
 emoji_styles = {
     'twemoji': [
-        'https://twemoji.maxcdn.com/v/latest/twemoji.min.js',
+        'https://unpkg.com/twemoji@latest/dist/twemoji.min.js',
         'twemoji.js',
         'twemoji.css',
     ],

--- a/sphinxemoji/sphinxemoji.py
+++ b/sphinxemoji/sphinxemoji.py
@@ -12,11 +12,13 @@ from sphinx.util.fileutil import copy_asset
 from . import __version__
 
 emoji_styles = {
-    'twemoji': [
-        'https://unpkg.com/twemoji@latest/dist/twemoji.min.js',
-        'twemoji.js',
-        'twemoji.css',
-    ],
+    'twemoji': {
+        'source': 'https://unpkg.com/twemoji@latest/dist/twemoji.min.js',
+        'libs': [
+            'twemoji.js',
+            'twemoji.css',
+        ]
+    },
 }
 
 
@@ -90,8 +92,10 @@ def copy_asset_files(app, exc):
 def setup(app):
     app.connect('build-finished', copy_asset_files)
     style = app.config._raw_config.get('sphinxemoji_style')
+    source = app.config._raw_config.get('sphinxemoji_source', emoji_styles[style]['source'])
     if style in emoji_styles:
-        for fname in emoji_styles[style]:
+        app.add_js_file(source)
+        for fname in emoji_styles[style]['libs']:
             if fname.endswith('.js'):
                 app.add_js_file(fname)
             elif fname.endswith('.css'):


### PR DESCRIPTION
MaxCDN is defunct: https://github.com/twitter/twemoji/issues/580

There is a new CDN url on unpkg. It's apparently not fully updated yet, as the twemoji.min.js there still references maxcdn as baseurl for the individual images, but they'll probably fix that soon.

The PR also adds the ability to configure your own `sphinxemoji_source` to use your own CDN or possibly store it as local files in the projects repository similar to other js and css files.